### PR TITLE
Removing NL IBAN check and add recurring properties for payment request

### DIFF
--- a/Source/CM.Payments.Client.Shared/Model/PaymentRequest.cs
+++ b/Source/CM.Payments.Client.Shared/Model/PaymentRequest.cs
@@ -1,7 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿using CM.Payments.Client.Converters;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using System;
-using CM.Payments.Client.Converters;
 
 namespace CM.Payments.Client.Model
 {
@@ -34,5 +34,18 @@ namespace CM.Payments.Client.Model
         /// </summary>
         [JsonProperty("currency")]
         public string Currency { get; set; }
+
+        /// <summary>
+        /// Whether the payment is a recurring payment, or not.
+        /// </summary>
+        [JsonProperty("recurring")]
+        public bool Recurring { get; set; }
+
+        /// <summary>
+        /// Unique identifier of the recurring payment.
+        /// </summary>
+        /// <remarks>Can be empty when it is the first of a recurring payment.</remarks>
+        [JsonProperty("recurring_id")]
+        public string RecurringId { get; set; }
     }
 }

--- a/Source/CM.Payments.Client.Shared/Validators/AfterPayDetailsValidator.cs
+++ b/Source/CM.Payments.Client.Shared/Validators/AfterPayDetailsValidator.cs
@@ -9,7 +9,7 @@ namespace CM.Payments.Client.Validators
     {
         public AfterPayDetailsValidator()
         {
-            RuleFor(d => d.BankAccountNumber).NotNull().Must(BeAValidIban);
+            RuleFor(d => d.BankAccountNumber).NotNull();
             RuleFor(d => d.InvoiceNumber).NotNull().Length(2, 15);
             RuleFor(d => d.IpAddress).NotNull().Must(BeAValidIpAddress);
             RuleFor(d => d.OrderNumber).NotNull().Length(2, 25);

--- a/Source/CM.Payments.Client.Shared/Validators/BaseValidator.cs
+++ b/Source/CM.Payments.Client.Shared/Validators/BaseValidator.cs
@@ -33,16 +33,6 @@ namespace CM.Payments.Client.Validators
         }
 
         /// <summary>
-        /// Check if provided string is a valid iban.
-        /// </summary>
-        /// <param name="iban">The iban.</param>
-        /// <returns></returns>
-        internal static bool BeAValidIban([NotNull] string iban)
-        {
-            return Regex.IsMatch(iban, @"^[A-Z]{2}[0-9]{2}[A-Z]{4}[0-9]{10}$");
-        }
-
-        /// <summary>
         /// Check if provided string is a valid currency.
         /// </summary>
         /// <param name="currency">The iban.</param>

--- a/Source/CM.Payments.Client.Shared/Validators/DirectDebitDetailsValidator.cs
+++ b/Source/CM.Payments.Client.Shared/Validators/DirectDebitDetailsValidator.cs
@@ -1,7 +1,5 @@
 ﻿using CM.Payments.Client.Model;
 using FluentValidation;
-using JetBrains.Annotations;
-using System.Text.RegularExpressions;
 
 namespace CM.Payments.Client.Validators
 {
@@ -9,7 +7,7 @@ namespace CM.Payments.Client.Validators
     {
         public DirectDebitDetailsValidator()
         {
-            RuleFor(d => d.BankAccountNumber).NotNull().Must(BeAValidIban);
+            RuleFor(d => d.BankAccountNumber).NotNull();
             RuleFor(d => d.Name).NotNull();
             RuleFor(d => d.MandateId).NotNull().Length(1, 35);
             RuleFor(d => d.PurchaseId).NotNull().Length(1, 35);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.12.{build}
+version: 1.2.0.{build}
 image: Visual Studio 2017
 configuration: Release
 assembly_info:


### PR DESCRIPTION
Removed the IBAN check for NL-specific IBANs, because non-Dutch IBANs where not allowed by the SDK. While there were allowed at the PSP.

Also added recurring properties to the payment request model, to be inline with the payment reponse model.