### PR TITLE
Fixed dependencies

### DIFF
--- a/Source/CM.Payments.Client.Core/CM.Payments.Client.Core.csproj
+++ b/Source/CM.Payments.Client.Core/CM.Payments.Client.Core.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="6.4.0" />
+    <PackageReference Include="FluentValidation" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />

--- a/Source/CM.Payments.Client.Net45/CM.Payments.Client.Net45.csproj
+++ b/Source/CM.Payments.Client.Net45/CM.Payments.Client.Net45.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\CM.Payments.Client.Net45.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentValidation, Version=6.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentValidation.6.4.0\lib\Net45\FluentValidation.dll</HintPath>
+    <Reference Include="FluentValidation, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.7.0.0\lib\net45\FluentValidation.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Source/CM.Payments.Client.Net45/packages.config
+++ b/Source/CM.Payments.Client.Net45/packages.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentValidation" version="6.4.0" targetFramework="net452" />
+  <package id="FluentValidation" version="7.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.4.1" targetFramework="net452" />

--- a/Source/CM.Payments.Client.Test/CM.Payments.Client.Test.45.csproj
+++ b/Source/CM.Payments.Client.Test/CM.Payments.Client.Test.45.csproj
@@ -41,8 +41,8 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FluentValidation, Version=6.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentValidation.6.4.0\lib\Net45\FluentValidation.dll</HintPath>
+    <Reference Include="FluentValidation, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7de548da2fbae0f0, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentValidation.7.0.0\lib\net45\FluentValidation.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>

--- a/Source/CM.Payments.Client.Test/packages.config
+++ b/Source/CM.Payments.Client.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
-  <package id="FluentValidation" version="6.4.0" targetFramework="net452" />
+  <package id="FluentValidation" version="7.0.0" targetFramework="net452" />
   <package id="Moq" version="4.8.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />

--- a/Source/CM.Payments.SDK.nuspec
+++ b/Source/CM.Payments.SDK.nuspec
@@ -20,12 +20,10 @@
     <!-- Dependencies are automatically installed when the package is installed -->
     <dependencies>
       <group targetFramework="net45">
-        <dependency id="FluentValidation" version="6.4.0" />
-        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="FluentValidation" version="7.0.0" />
       </group>
       <group targetFramework="netcore">
-        <dependency id="FluentValidation" version="6.4.0" />
-        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="FluentValidation" version="7.0.0" />
         <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
       </group>
       <group targetFramework="net40">

--- a/Source/CM.Payments.SDK.nuspec
+++ b/Source/CM.Payments.SDK.nuspec
@@ -21,14 +21,16 @@
     <dependencies>
       <group targetFramework="net45">
         <dependency id="FluentValidation" version="7.0.0" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" />
       </group>
       <group targetFramework="netcore">
         <dependency id="FluentValidation" version="7.0.0" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" />
         <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
       </group>
       <group targetFramework="net40">
         <dependency id="FluentValidation" version="6.4.0" />
-        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="Newtonsoft.Json" version="11.0.2" />
         <dependency id="Microsoft.Bcl" version="1.1.10" />
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
         <dependency id="Microsoft.Bcl.Build" version="1.0.21" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.2.2.{build}
+version: 1.2.3.{build}
 image: Visual Studio 2017
 configuration: Release
 assembly_info:


### PR DESCRIPTION
Projects which use a higher version of 6.4.0 of FluentValidation failed to import the SDK due to that version of FluentValidation not having a strong name. Which prevent the usage of bindingRedirects. Upgraded FluentValidation to version 7.0.0, which is the first version with a strong name. 

Fixed the Newtonsoft.Json dependency in the .nuspec to reflect the used packages in the implementation.