### PR TITLE
Upgrade version of supported framework and fluent validator

### DIFF
--- a/Source/CM.Payments.Client.Core/CM.Payments.Client.Core.csproj
+++ b/Source/CM.Payments.Client.Core/CM.Payments.Client.Core.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.2.2" />
+    <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />

--- a/Source/CM.Payments.Client.Core/CM.Payments.Client.Core.csproj
+++ b/Source/CM.Payments.Client.Core/CM.Payments.Client.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>CM.Payments.Client.Core</AssemblyName>
     <PackageId>CM.Payments.Client.Core</PackageId>
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="7.0.0" />
+    <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />

--- a/Source/CM.Payments.Client.Core/Properties/AssemblyInfo.cs
+++ b/Source/CM.Payments.Client.Core/Properties/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyProduct("CM Payments SDK Client .net Core 1.6")]
+[assembly: AssemblyProduct("CM Payments SDK Client .net standard 2.1")]

--- a/Source/CM.Payments.Client.Shared/AssemblyInfo.cs
+++ b/Source/CM.Payments.Client.Shared/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright © 2017")]
 
 [assembly: AssemblyVersion("1.1.11.0")]
-[assembly: AssemblyInformationalVersion("1.1.11.0")]
+[assembly: AssemblyInformationalVersion("1.2.0.0")]
 [assembly: AssemblyFileVersion("1.1.11.0")]
 
 [assembly: InternalsVisibleTo("CM.Payments.Client.Test")]

--- a/Source/CM.Payments.Client.Shared/PaymentClient.cs
+++ b/Source/CM.Payments.Client.Shared/PaymentClient.cs
@@ -11,10 +11,36 @@ using JetBrains.Annotations;
 namespace CM.Payments.Client
 {
     /// <summary>
+    ///     Client interface for CM Payments API.
+    /// </summary>
+    public interface IPaymentClient
+    {
+        Task<ChargeResponse> GetChargeAsync(string id, CancellationToken cancellationToken = default);
+
+        Task<List<Issuer>> GetIssuersAsync(CancellationToken cancellationToken = default);
+
+        Task<PaymentResponse> GetPaymentAsync([NotNull] string id, CancellationToken cancellationToken = default);
+
+        Task<QrResponse> GetQrAsync([NotNull] string id, CancellationToken cancellationToken = default);
+
+        Task<QrResponse> GetQrStatusAsync([NotNull] string id, CancellationToken cancellationToken = default);
+
+        Task<RefundResponse> GetRefundAsync([NotNull] string id, CancellationToken cancellationToken = default);
+
+        Task<ChargeResponse> PayAsync(ChargeRequest charge, CancellationToken cancellationToken = default);
+
+        Task<QrResponse> QrAsync(QrRequest qr, CancellationToken cancellationToken = default);
+
+        Task<MultiQrResponse> MultiQrAsync(MultiQrRequest request, CancellationToken cancellationToken = default);
+
+        Task<RefundResponse> RefundAsync([NotNull] RefundRequest refund, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
     ///     Client for CM Payments API.
     /// </summary>
     [PublicAPI]
-    public sealed class PaymentClient : RestBaseClient
+    public sealed class PaymentClient : RestBaseClient, IPaymentClient
     {
         private readonly ChargeValidator _chargeValidator;
         private readonly QrValidator _qrValidator;
@@ -56,7 +82,7 @@ namespace CM.Payments.Client
         public async Task<List<Issuer>> GetIssuersAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var result = await GetAsync<Dictionary<string, string>>($"issuers/{ApiVersion}/ideal", cancellationToken).ConfigureAwait(false);
-            return result.Select(p => new Issuer {Name = p.Key, ID = p.Value}).ToList();
+            return result.Select(p => new Issuer { Name = p.Key, ID = p.Value }).ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
Hi. 

We use latest versions of .net core 3.1 and latest fluent validator.

Current implementation fails during call of the client constructor with the error: 
Error: Method not found: 'Void FluentValidation.AbstractValidator`1.When(System.Func`2<!0,Boolean>, System.Action)

to fix the error it is needed to update fluent validator to version 8.6.2 where SetCollectionValidator is present